### PR TITLE
Get Contact API Endpoint

### DIFF
--- a/Bruno/Get Contact (Does Not Exist).bru
+++ b/Bruno/Get Contact (Does Not Exist).bru
@@ -1,0 +1,11 @@
+meta {
+  name: Get Contact (Does Not Exist)
+  type: http
+  seq: 4
+}
+
+get {
+  url: http://localhost:5158/api/v1/contacts/-1
+  body: none
+  auth: none
+}

--- a/Bruno/Get Contact (Exists).bru
+++ b/Bruno/Get Contact (Exists).bru
@@ -1,0 +1,11 @@
+meta {
+  name: Get Contact (Exists)
+  type: http
+  seq: 3
+}
+
+get {
+  url: http://localhost:5158/api/v1/contacts/3
+  body: none
+  auth: none
+}

--- a/Bruno/Get Contacts.bru
+++ b/Bruno/Get Contacts.bru
@@ -5,7 +5,7 @@ meta {
 }
 
 get {
-  url: http://localhost:5105/api/v1/contacts
+  url: http://localhost:5158/api/v1/contacts
   body: none
   auth: none
 }

--- a/ContactHouse.API.Test/Endpoints/GetContactTest.cs
+++ b/ContactHouse.API.Test/Endpoints/GetContactTest.cs
@@ -1,0 +1,62 @@
+﻿namespace ContactHouse.API.Test.Endpoints;
+using ContactHouse.API.DTOs;
+using ContactHouse.API.Endpoints;
+using System.Net;
+using System.Net.Http.Json;
+
+[TestFixture]
+public sealed class GetContactTest : ContactEndpointsTest
+{
+	[Test]
+	public async Task GivenEmptyDatabase_WhenGetContact_ThenReturnsResponseWithNotFoundStatus()
+	{
+		var response = await GetAsync(1);
+
+		Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+	}
+
+	[Test]
+	public async Task GivenNonEmptyDatabaseAndContactIdThatExists_WhenGetContact_ThenReturnsResponseWithOkStatus()
+	{
+		await SeedDatabaseAsync();
+
+		var response = await GetAsync(1);
+
+		Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.OK));
+	}
+
+	[Test]
+	public async Task GivenNonEmptyDatabaseAndContactIdThatExists_WhenGetContact_ThenReturnsResponseContainingContact()
+	{
+		await SeedDatabaseAsync();
+
+		var response = await GetAsync(1);
+		var contact = await response.Content.ReadFromJsonAsync<ResponseContactDTO>();
+
+		Assert.That(contact, Is.Not.Null);
+		Assert.Multiple(() =>
+		{
+			Assert.That(contact.ContactId, Is.EqualTo(1));
+			Assert.That(contact.FirstName, Is.EqualTo("John"));
+			Assert.That(contact.LastName, Is.EqualTo("Doe"));
+			Assert.That(contact.CompanyName, Is.EqualTo("Doe Incorporated"));
+		});
+	}
+
+	[Test]
+	public async Task GivenNonEmptyDatabaseAndContactIdThatDoesNotExist_WhenGetContact_ThenReturnsResponseWithNotFoundStatus()
+	{
+		await SeedDatabaseAsync();
+
+		var response = await GetAsync(-1);
+
+		Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+	}
+
+	private async Task<HttpResponseMessage> GetAsync(int contactId)
+	{
+		using var client = WebApplicationFactory.CreateClient();
+
+		return await client.GetAsync($"{ContactEndpoints.Url}/{contactId}");
+	}
+}

--- a/ContactHouse.API/DTOs/ResponseContactDTO.cs
+++ b/ContactHouse.API/DTOs/ResponseContactDTO.cs
@@ -1,0 +1,8 @@
+﻿namespace ContactHouse.API.DTOs;
+public class ResponseContactDTO
+{
+	public int ContactId { get; set; }
+	public string FirstName { get; set; }
+	public string? LastName { get; set; }
+	public string? CompanyName { get; set; }
+}

--- a/ContactHouse.API/Endpoints/ContactEndpoints.cs
+++ b/ContactHouse.API/Endpoints/ContactEndpoints.cs
@@ -8,5 +8,6 @@ public static class ContactEndpoints
 		var endpoint = webApplication.MapGroup(ContactEndpoints.Url);
 
 		endpoint.MapGet("/", GetContacts.HandleAsync);
+		endpoint.MapGet("/{contactId}", GetContact.HandleAsync);
 	}
 }

--- a/ContactHouse.API/Endpoints/GetContact.cs
+++ b/ContactHouse.API/Endpoints/GetContact.cs
@@ -1,0 +1,23 @@
+﻿namespace ContactHouse.API.Endpoints;
+using AutoMapper;
+using ContactHouse.API.DTOs;
+using ContactHouse.Services.Retrieval;
+
+public static class GetContact
+{
+	public async static Task<IResult> HandleAsync(IContactRetrievalService contactRetrievalService,
+												  IMapper mapper,
+												  int contactId)
+	{
+		var contact = await contactRetrievalService.GetContactAsync(contactId);
+
+		if (contact == null)
+		{
+			return Results.NotFound();
+		}
+
+		var response = mapper.Map<ResponseContactDTO>(contact);
+
+		return Results.Ok(response);
+	}
+}

--- a/ContactHouse.API/Profiles/ResponseContactProfile.cs
+++ b/ContactHouse.API/Profiles/ResponseContactProfile.cs
@@ -7,6 +7,7 @@ public sealed class ResponseContactProfile : Profile
 {
 	public ResponseContactProfile()
 	{
+		CreateMap<ContactDTO, ResponseContactDTO>();
 		CreateMap<PartialContactDTO, ResponsePartialContactDTO>();
 	}
 }

--- a/ContactHouse.Domain/DTOs/ContactDTO.cs
+++ b/ContactHouse.Domain/DTOs/ContactDTO.cs
@@ -1,0 +1,8 @@
+﻿namespace ContactHouse.Domain.DTOs;
+public class ContactDTO
+{
+	public int ContactId { get; set; }
+	public string FirstName { get; set; }
+	public string? LastName { get; set; }
+	public string? CompanyName { get; set; }
+}

--- a/ContactHouse.Domain/Profiles/ContactProfile.cs
+++ b/ContactHouse.Domain/Profiles/ContactProfile.cs
@@ -7,6 +7,7 @@ public sealed class ContactProfile : Profile
 {
 	public ContactProfile()
 	{
+		CreateMap<Contact, ContactDTO>();
 		CreateMap<Contact, PartialContactDTO>();
 	}
 }

--- a/ContactHouse.Persistence.Test/Repositories/ContactRepositoryTest.cs
+++ b/ContactHouse.Persistence.Test/Repositories/ContactRepositoryTest.cs
@@ -61,6 +61,29 @@ public sealed class ContactRepositoryTest
 		Assert.That(contacts, Has.Exactly(2).Items);
 	}
 
+	[Test]
+	public async Task GivenEmptyDatabaseContext_WhenGetContactAsync_ThenReturnsNoContacts()
+	{
+		var contact = await contactRepository.GetContactAsync(1);
+
+		Assert.That(contact, Is.Null);
+	}
+
+	[Test]
+	public async Task GivenNonEmptyDatabaseContext_WhenGetContactAsync_ThenReturnsContact()
+	{
+		await SeedDatabaseAsync();
+
+		var contact = await contactRepository.GetContactAsync(1);
+
+		Assert.That(contact, Is.Not.Null);
+		Assert.Multiple(() =>
+		{
+			Assert.That(contact.ContactId, Is.EqualTo(1));
+			Assert.That(contact.FirstName, Is.EqualTo("John"));
+		});
+	}
+
 	private async Task SeedDatabaseAsync()
 	{
 		await contactDatabaseContext.Contacts.AddRangeAsync(databaseContacts);

--- a/ContactHouse.Persistence/Repositories/ContactRepository.cs
+++ b/ContactHouse.Persistence/Repositories/ContactRepository.cs
@@ -16,4 +16,9 @@ public sealed class ContactRepository : IContactRepository
 	{
 		return await contactDatabaseContext.Contacts.ToListAsync();
 	}
+
+	public async Task<Contact?> GetContactAsync(int contactId)
+	{
+		return await contactDatabaseContext.Contacts.FirstOrDefaultAsync(contact => contact.ContactId == contactId);
+	}
 }

--- a/ContactHouse.Persistence/Repositories/IContactRepository.cs
+++ b/ContactHouse.Persistence/Repositories/IContactRepository.cs
@@ -4,4 +4,5 @@ using ContactHouse.Domain.Entities;
 public interface IContactRepository
 {
 	public Task<IEnumerable<Contact>> GetContactsAsync();
+	public Task<Contact?> GetContactAsync(int contactId);
 }

--- a/ContactHouse.Services.Test/Retrieval/ContactRetrievalServiceTest.cs
+++ b/ContactHouse.Services.Test/Retrieval/ContactRetrievalServiceTest.cs
@@ -56,4 +56,27 @@ public sealed class ContactRetrievalServiceTest
 
 		Assert.That(contacts, Has.Exactly(2).Items);
 	}
+
+	[Test]
+	public async Task GivenEmptyDatabase_WhenGetContactAsync_ThenReturnsNoContact()
+	{
+		mockContactRepository.Setup(mock => mock.GetContactAsync(It.IsAny<int>()))
+							 .ReturnsAsync(() => null);
+
+		var contact = await contactRetrievalService.GetContactAsync(1);
+
+		Assert.That(contact, Is.Null);
+	}
+
+	[Test]
+	public async Task GivenNonEmptyDatabase_WhenGetContactAsync_ThenReturnsContact()
+	{
+		mockContactRepository.Setup(mock => mock.GetContactAsync(1))
+							 .ReturnsAsync(databaseContacts[0]);
+
+		var contact = await contactRetrievalService.GetContactAsync(1);
+
+		Assert.That(contact, Is.Not.Null);
+		Assert.That(contact.ContactId, Is.EqualTo(1));
+	}
 }

--- a/ContactHouse.Services/Retrieval/ContactRetrievalService.cs
+++ b/ContactHouse.Services/Retrieval/ContactRetrievalService.cs
@@ -20,4 +20,11 @@ public sealed class ContactRetrievalService : IContactRetrievalService
 
 		return mapper.Map<IEnumerable<PartialContactDTO>>(contacts);
 	}
+
+	public async Task<ContactDTO?> GetContactAsync(int contactId)
+	{
+		var contact = await contactRepository.GetContactAsync(contactId);
+
+		return mapper.Map<ContactDTO>(contact);
+	}
 }

--- a/ContactHouse.Services/Retrieval/IContactRetrievalService.cs
+++ b/ContactHouse.Services/Retrieval/IContactRetrievalService.cs
@@ -4,4 +4,5 @@ using ContactHouse.Domain.DTOs;
 public interface IContactRetrievalService
 {
 	public Task<IEnumerable<PartialContactDTO>> GetContactsAsync();
+	public Task<ContactDTO?> GetContactAsync(int contactId);
 }


### PR DESCRIPTION
# Changelog

This pull request focuses on implement the `GET /api/v1/contacts/{contactId}` endpoint for retrieving a specific `Contact` entity by its `ContactId` property.

## Added

### Bruno

- Added a `GET /api/v1/contacts/{contactId}` endpoint test for retrieving an existing `Contact` entity.
- Added a `GET /api/v1/contacts/{contactId}` endpoint test for retrieving a non-existing `Contact` entity.

### API

- Added the `ResponseContactDTO` class.
- Added the `ResponseContactDTO.ContactId` auto property.
- Added the `ResponseContactDTO.FirstName` auto property.
- Added the `ResponseContactDTO.LastName` auto property.
- Added the `ResponseContactDTO.CompanyName` auto property.
- Added an `AutoMapper` mapping for `ContactDTO` to `ResponseContactDTO`.
- Added the `GetContact` class.
- Added an implementation for the `GetContact.HandleAsync` method.
- Added the `GET /api/v1/contacts/{contactId}` endpoint mapping.

### Domain

- Added the `ContactDTO` class.
- Added the `ContactDTO.ContactId` auto property.
- Added the `ContactDTO.FirstName` auto property.
- Added the `ContactDTO.LastName` auto property.
- Added the `ContactDTO.CompanyName` auto property.
- Added an `AutoMapper` mapping for `Contact` to `ContactDTO`.

### Persistence

- Added the `IContactRepository.GetContactAsync` method.
- Added an implementation for the `ContactRepository.GetContactAsync` method.

### Services

- Added the `IContactRetrievalService.GetContactAsync` method.
- Added an implementation for the `ContactRetrievalService.GetContactAsync` method.

## Changed

### Bruno

- Changed the `GET /api/v1/contacts` endpoint test's port number.

## Removed