### PR TITLE
Delete Contact API Endpoint

### DIFF
--- a/Bruno/Delete Contact (Does Not Exist).bru
+++ b/Bruno/Delete Contact (Does Not Exist).bru
@@ -1,0 +1,11 @@
+meta {
+  name: Delete Contact (Does Not Exist)
+  type: http
+  seq: 6
+}
+
+delete {
+  url: http://localhost:5158/api/v1/contacts/-1
+  body: none
+  auth: none
+}

--- a/Bruno/Delete Contact (Exists).bru
+++ b/Bruno/Delete Contact (Exists).bru
@@ -1,0 +1,11 @@
+meta {
+  name: Delete Contact (Exists)
+  type: http
+  seq: 5
+}
+
+delete {
+  url: http://localhost:5158/api/v1/contacts/1
+  body: none
+  auth: none
+}

--- a/ContactHouse.API.Test/Endpoints/DeleteContactTest.cs
+++ b/ContactHouse.API.Test/Endpoints/DeleteContactTest.cs
@@ -1,0 +1,42 @@
+﻿namespace ContactHouse.API.Test.Endpoints;
+using ContactHouse.API.Endpoints;
+using System.Net;
+
+[TestFixture]
+public sealed class DeleteContactTest : ContactEndpointsTest
+{
+	[Test]
+	public async Task GivenEmptyDatabase_WhenDeleteContact_ThenReturnsResponseWithNotFoundStatus()
+	{
+		var response = await DeleteAsync(1);
+
+		Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+	}
+
+	[Test]
+	public async Task GivenNonEmptyDatabaseAndContactIdThatExists_WhenDeleteContact_ThenReturnsResponseWithNoContent()
+	{
+		await SeedDatabaseAsync();
+
+		var response = await DeleteAsync(1);
+
+		Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NoContent));
+	}
+
+	[Test]
+	public async Task GivenNonEmptyDatabaseAndContactIdThatDoesNotExist_WhenDeleteContact_ThenReturnsResponseWithNotFoundStatus()
+	{
+		await SeedDatabaseAsync();
+
+		var response = await DeleteAsync(-1);
+
+		Assert.That(response.StatusCode, Is.EqualTo(HttpStatusCode.NotFound));
+	}
+
+	private async Task<HttpResponseMessage> DeleteAsync(int contactId)
+	{
+		using var client = WebApplicationFactory.CreateClient();
+
+		return await client.DeleteAsync($"{ContactEndpoints.Url}/{contactId}");
+	}
+}

--- a/ContactHouse.API/Endpoints/ContactEndpoints.cs
+++ b/ContactHouse.API/Endpoints/ContactEndpoints.cs
@@ -9,5 +9,6 @@ public static class ContactEndpoints
 
 		endpoint.MapGet("/", GetContacts.HandleAsync);
 		endpoint.MapGet("/{contactId}", GetContact.HandleAsync);
+		endpoint.MapDelete("/{contactId}", DeleteContact.HandleAsync);
 	}
 }

--- a/ContactHouse.API/Endpoints/DeleteContact.cs
+++ b/ContactHouse.API/Endpoints/DeleteContact.cs
@@ -1,0 +1,12 @@
+﻿namespace ContactHouse.API.Endpoints;
+using ContactHouse.Services.Deletion;
+
+public static class DeleteContact
+{
+	public async static Task<IResult> HandleAsync(IContactDeletionService contactDeletionService, int contactId)
+	{
+		var wasDeleted = await contactDeletionService.DeleteContactAsync(contactId);
+
+		return wasDeleted ? Results.NoContent() : Results.NotFound();
+	}
+}

--- a/ContactHouse.API/Program.cs
+++ b/ContactHouse.API/Program.cs
@@ -4,6 +4,7 @@ using ContactHouse.API.Profiles;
 using ContactHouse.Domain.Profiles;
 using ContactHouse.Persistence.Databases;
 using ContactHouse.Persistence.Repositories;
+using ContactHouse.Services.Deletion;
 using ContactHouse.Services.Retrieval;
 using Microsoft.EntityFrameworkCore;
 
@@ -57,6 +58,7 @@ public class Program
 	private static void RegisterContactServices(WebApplicationBuilder webApplicationBuilder)
 	{
 		webApplicationBuilder.Services.AddScoped<IContactRetrievalService, ContactRetrievalService>();
+		webApplicationBuilder.Services.AddScoped<IContactDeletionService, ContactDeletionService>();
 	}
 
 	private static void RegisterRepositories(WebApplicationBuilder webApplicationBuilder)

--- a/ContactHouse.Persistence.Test/Repositories/ContactRepositoryTest.cs
+++ b/ContactHouse.Persistence.Test/Repositories/ContactRepositoryTest.cs
@@ -94,6 +94,34 @@ public sealed class ContactRepositoryTest
 		Assert.That(contact, Is.Null);
 	}
 
+	[Test]
+	public async Task GivenEmptyDatabaseContext_WhenDeleteContactAsync_ThenReturnsFalse()
+	{
+		var wasDeleted = await contactRepository.DeleteContactAsync(1);
+
+		Assert.That(wasDeleted, Is.False);
+	}
+
+	[Test]
+	public async Task GivenNonEmptyDatabaseContextAndContactIdThatExists_WhenDeleteContactAsync_ThenReturnsTrue()
+	{
+		await SeedDatabaseAsync();
+
+		var wasDeleted = await contactRepository.DeleteContactAsync(1);
+
+		Assert.That(wasDeleted, Is.True);
+	}
+
+	[Test]
+	public async Task GivenNonEmptyDatabaseContextAndContactIdThatDoesNotExist_WhenDeleteContactAsync_ThenReturnsFalse()
+	{
+		await SeedDatabaseAsync();
+
+		var wasDeleted = await contactRepository.DeleteContactAsync(-1);
+
+		Assert.That(wasDeleted, Is.False);
+	}
+
 	private async Task SeedDatabaseAsync()
 	{
 		await contactDatabaseContext.Contacts.AddRangeAsync(databaseContacts);

--- a/ContactHouse.Persistence.Test/Repositories/ContactRepositoryTest.cs
+++ b/ContactHouse.Persistence.Test/Repositories/ContactRepositoryTest.cs
@@ -44,7 +44,7 @@ public sealed class ContactRepositoryTest
 	}
 
 	[Test]
-	public async Task GivenEmptyDatabaseContext_WhenGetContactsAsync_ThenReturnsNoContacts()
+	public async Task GivenEmptyDatabaseContext_WhenGetContactsAsync_ThenReturnsEmptyEnumerable()
 	{
 		var contacts = (await contactRepository.GetContactsAsync()).ToList();
 

--- a/ContactHouse.Persistence.Test/Repositories/ContactRepositoryTest.cs
+++ b/ContactHouse.Persistence.Test/Repositories/ContactRepositoryTest.cs
@@ -62,7 +62,7 @@ public sealed class ContactRepositoryTest
 	}
 
 	[Test]
-	public async Task GivenEmptyDatabaseContext_WhenGetContactAsync_ThenReturnsNoContacts()
+	public async Task GivenEmptyDatabaseContext_WhenGetContactAsync_ThenReturnsNull()
 	{
 		var contact = await contactRepository.GetContactAsync(1);
 
@@ -70,7 +70,7 @@ public sealed class ContactRepositoryTest
 	}
 
 	[Test]
-	public async Task GivenNonEmptyDatabaseContext_WhenGetContactAsync_ThenReturnsContact()
+	public async Task GivenNonEmptyDatabaseContextAndContactIdThatExists_WhenGetContactAsync_ThenReturnsContact()
 	{
 		await SeedDatabaseAsync();
 
@@ -82,6 +82,16 @@ public sealed class ContactRepositoryTest
 			Assert.That(contact.ContactId, Is.EqualTo(1));
 			Assert.That(contact.FirstName, Is.EqualTo("John"));
 		});
+	}
+
+	[Test]
+	public async Task GivenNonEmptyDatabaseContextAndContactIdThatDoesNotExist_WhenGetContactAsync_ThenReturnsNull()
+	{
+		await SeedDatabaseAsync();
+
+		var contact = await contactRepository.GetContactAsync(-1);
+
+		Assert.That(contact, Is.Null);
 	}
 
 	private async Task SeedDatabaseAsync()

--- a/ContactHouse.Persistence/Repositories/ContactRepository.cs
+++ b/ContactHouse.Persistence/Repositories/ContactRepository.cs
@@ -21,4 +21,20 @@ public sealed class ContactRepository : IContactRepository
 	{
 		return await contactDatabaseContext.Contacts.FirstOrDefaultAsync(contact => contact.ContactId == contactId);
 	}
+
+	public async Task<bool> DeleteContactAsync(int contactId)
+	{
+		var contact = await GetContactAsync(contactId);
+
+		if (contact == null)
+		{
+			return false;
+		}
+
+		contactDatabaseContext.Contacts.Remove(contact);
+
+		var resultCount = await contactDatabaseContext.SaveChangesAsync();
+
+		return resultCount > 0;
+	}
 }

--- a/ContactHouse.Persistence/Repositories/IContactRepository.cs
+++ b/ContactHouse.Persistence/Repositories/IContactRepository.cs
@@ -5,4 +5,5 @@ public interface IContactRepository
 {
 	public Task<IEnumerable<Contact>> GetContactsAsync();
 	public Task<Contact?> GetContactAsync(int contactId);
+	public Task<bool> DeleteContactAsync(int contactId);
 }

--- a/ContactHouse.Services.Test/Deletion/ContactDeletionServiceTest.cs
+++ b/ContactHouse.Services.Test/Deletion/ContactDeletionServiceTest.cs
@@ -1,0 +1,44 @@
+﻿namespace ContactHouse.Services.Test.Deletion;
+using AutoMapper;
+using ContactHouse.Domain.Entities;
+using ContactHouse.Domain.Profiles;
+using ContactHouse.Persistence.Repositories;
+using ContactHouse.Services.Deletion;
+using Moq;
+
+[TestFixture]
+public sealed class ContactDeletionServiceTest
+{
+	private Mock<IContactRepository> mockContactRepository;
+	private ContactDeletionService contactDeletionService;
+
+	[SetUp]
+	public void SetUp()
+	{
+		mockContactRepository = new Mock<IContactRepository>();
+		contactDeletionService = new ContactDeletionService(mockContactRepository.Object);
+	}
+
+	[Test]
+	public async Task GivenContactDatabaseAndContactIdThatDoesNotExist_WhenDeleteContactAsync_ThenReturnsFalse()
+	{
+		mockContactRepository.Setup(mock => mock.DeleteContactAsync(It.IsAny<int>()))
+							 .ReturnsAsync(false);
+
+		var wasDeleted = await contactDeletionService.DeleteContactAsync(1);
+
+		Assert.That(wasDeleted, Is.False);
+	}
+
+	[Test]
+	public async Task GivenContactDatabaseAndContactIdThatExists_WhenDeleteContactAsync_ThenReturnsTrue()
+	{
+
+		mockContactRepository.Setup(mock => mock.DeleteContactAsync(1))
+							 .ReturnsAsync(true);
+
+		var wasDeleted = await contactDeletionService.DeleteContactAsync(1);
+
+		Assert.That(wasDeleted, Is.True);
+	}
+}

--- a/ContactHouse.Services.Test/Retrieval/ContactRetrievalServiceTest.cs
+++ b/ContactHouse.Services.Test/Retrieval/ContactRetrievalServiceTest.cs
@@ -36,7 +36,7 @@ public sealed class ContactRetrievalServiceTest
 	}
 
 	[Test]
-	public async Task GivenEmptyDatabase_WhenGetContactsAsync_ThenReturnsNoContacts()
+	public async Task GivenEmptyDatabase_WhenGetContactsAsync_ThenReturnsEmptyEnumerable()
 	{
 		mockContactRepository.Setup(mock => mock.GetContactsAsync())
 							 .ReturnsAsync(new List<Contact>());
@@ -58,7 +58,7 @@ public sealed class ContactRetrievalServiceTest
 	}
 
 	[Test]
-	public async Task GivenEmptyDatabase_WhenGetContactAsync_ThenReturnsNoContact()
+	public async Task GivenEmptyDatabase_WhenGetContactAsync_ThenReturnsNull()
 	{
 		mockContactRepository.Setup(mock => mock.GetContactAsync(It.IsAny<int>()))
 							 .ReturnsAsync(() => null);
@@ -69,7 +69,7 @@ public sealed class ContactRetrievalServiceTest
 	}
 
 	[Test]
-	public async Task GivenNonEmptyDatabase_WhenGetContactAsync_ThenReturnsContact()
+	public async Task GivenNonEmptyDatabaseAndContactIdThatExists_WhenGetContactAsync_ThenReturnsContact()
 	{
 		mockContactRepository.Setup(mock => mock.GetContactAsync(1))
 							 .ReturnsAsync(databaseContacts[0]);
@@ -78,5 +78,16 @@ public sealed class ContactRetrievalServiceTest
 
 		Assert.That(contact, Is.Not.Null);
 		Assert.That(contact.ContactId, Is.EqualTo(1));
+	}
+
+	[Test]
+	public async Task GivenNonEmptyDatabaseAndContactIdThatDoesNotExist_WhenGetContactAsync_ThenReturnsNull()
+	{
+		mockContactRepository.Setup(mock => mock.GetContactAsync(-1))
+							 .ReturnsAsync(() => null);
+
+		var contact = await contactRetrievalService.GetContactAsync(-1);
+
+		Assert.That(contact, Is.Null);
 	}
 }

--- a/ContactHouse.Services/Deletion/ContactDeletionService.cs
+++ b/ContactHouse.Services/Deletion/ContactDeletionService.cs
@@ -1,0 +1,17 @@
+﻿namespace ContactHouse.Services.Deletion;
+using ContactHouse.Persistence.Repositories;
+
+public class ContactDeletionService : IContactDeletionService
+{
+	private readonly IContactRepository contactRepository;
+
+	public ContactDeletionService(IContactRepository contactRepository)
+	{
+		this.contactRepository = contactRepository;
+	}
+
+	public async Task<bool> DeleteContactAsync(int contactId)
+	{
+		return await contactRepository.DeleteContactAsync(contactId);
+	}
+}

--- a/ContactHouse.Services/Deletion/IContactDeletionService.cs
+++ b/ContactHouse.Services/Deletion/IContactDeletionService.cs
@@ -1,0 +1,5 @@
+﻿namespace ContactHouse.Services.Deletion;
+public interface IContactDeletionService
+{
+	public Task<bool> DeleteContactAsync(int contactId);
+}


### PR DESCRIPTION
# Changelog

This pull request focuses on implementing the `DELETE /api/v1/contacts/{contactId}` endpoint for deleting a specific `Contact` entity by its `ContactId` property.

## Added

### API

- Added a scoped service registration for the `IContactDeletionService` interface.
- Added the `DeleteContact` class.
- Added an implementation for the `DeleteContact.HandleAsync` method.
- Added the `DELETE /api/v1/contacts/{contactId}` endpoint mapping.

### Bruno

- Added a `DELETE /api/v1/contacts/{contactId}` endpoint test for deleting an existing `Contact` entity.
- Added a `DELETE /api/v1/contacts/{contactId}` endpoint test for deleting a non-existing `Contact` entity.

### Domain

### Persistence

- Added the `IContactRepository.DeleteContactAsync` method.
- Added an implementation for the `ContactRepository.DeleteContactAsync` method.

### Services 

- Added the `IContactDeletionService` interface.
- Added the `IContactDeletionService.DeleteContactAsync` method.
- Added the `ContactDeletionService` class.
- Added an implementation for the `ContactDeletionService.DeleteContactAsync` method.

## Changed

## Removed